### PR TITLE
Binding svc to sd-jwt (Issue #31)

### DIFF
--- a/main.md
+++ b/main.md
@@ -234,6 +234,10 @@ holder and issuer MAY use pre-established key material.
 
 Note: need to define how holder public key is included, right now examples are using `sub_jwk` I think.
 
+#### Hash of an SVC
+* `svc_hash`
+  * REQUIRED. SVC hash value. Its value is the base64url encoding of the left-most half of the hash of the octets of the ASCII representation of the SVC value, where the hash algorithm used is the same hash algorithm that is used for the selectively disclosable claims in an SD-JWT. The svc_hash value is a case sensitive string.
+
 #### Other Claims
 
 The SD-JWT payload MAY contain other claims and will typically contain other JWT claims, such as `iss`, `iat`, etc. 

--- a/main.md
+++ b/main.md
@@ -445,10 +445,8 @@ separator.
 
 The SVC and SD-JWT are implicitly linked through the hash values of the claims
 in the SVC that is included in the SD-JWT. To ensure that the correct SVC and 
-SD-JWT pairings are being used, the holder should verify that all the claims 
-in the SVC are present in the SD-JWT, that there are no claims in the SD-JWT 
-that are not in the SVC and that the hashes of the claims in the SVC match 
-those in the SD-JWT.
+SD-JWT pairings are being used, the holder should verify the binding between
+SVC and SD-JWT, as defined in the Verification Section of this document.
 
 For Example 1, the combined format looks as follows:
 

--- a/main.md
+++ b/main.md
@@ -445,7 +445,7 @@ separator.
 
 The SVC and SD-JWT are implicitly linked through the hash values of the claims
 in the SVC that is included in the SD-JWT. To ensure that the correct SVC and 
-SD-JWT pairings are being used, the holder should verify the binding between
+SD-JWT pairings are being used, the holder SHOULD verify the binding between
 SVC and SD-JWT, as defined in the Verification Section of this document.
 
 For Example 1, the combined format looks as follows:

--- a/main.md
+++ b/main.md
@@ -605,9 +605,9 @@ HXHIka0SGRaOh8x6v5-rCQJl_IbM8wb7CSHvQ
 
 ## Verification by the Holder when Receiving SD-JWT and SVC
 
-The holder SHOULD verify the binding between SD-JWT and SVC by following the following steps:
+The holder SHOULD verify the binding between SD-JWT and SVC by performing the following steps:
  1. Check that all the claims in the SVC are present in the SD-JWT and that there are no claims in the SD-JWT that are not in the SVC
- 2. Check and that the hashes of the claims in the SVC match those in the SD-JWT
+ 2. Check that the hashes of the claims in the SVC match those in the SD-JWT
 
 ## Verification by the Verifier when Receiving SD-JWT and SD-JWT-R
 

--- a/main.md
+++ b/main.md
@@ -235,7 +235,9 @@ holder and issuer MAY use pre-established key material.
 Note: need to define how holder public key is included, right now examples are using `sub_jwk` I think.
 
 #### Hash of an SVC
+
 * `svc_hash`
+
   * REQUIRED. SVC hash value. Its value is the base64url encoding of the left-most half of the hash of the octets of the ASCII representation of the SVC value, where the hash algorithm used is the same hash algorithm that is used for the selectively disclosable claims in an SD-JWT. The svc_hash value is a case sensitive string.
 
 #### Other Claims

--- a/main.md
+++ b/main.md
@@ -446,7 +446,7 @@ separator.
 The SVC and SD-JWT are implicitly linked through the hash values of the claims
 in the SVC that is included in the SD-JWT. To ensure that the correct SVC and 
 SD-JWT pairings are being used, the holder SHOULD verify the binding between
-SVC and SD-JWT, as defined in the Verification Section of this document.
+SVC and SD-JWT as defined in the Verification Section of this document.
 
 For Example 1, the combined format looks as follows:
 


### PR DESCRIPTION
Issue #31. putting SVC has in SD-JWT to enable holder to match between SD-JWT and SVC