### PR TITLE
Editorial suggestions

### DIFF
--- a/main.md
+++ b/main.md
@@ -222,7 +222,7 @@ If holder binding is desired, `SD-JWT` must contain information about key materi
 SD-JWT-DOC = (METADATA, HOLDER-PUBLIC-KEY, SD-CLAIMS)
 ```
 
-Note: How the public key is included in SD-JWT is out of scope of this document. It can be passed by value or by reference. Examples in this document use `sub_jwt` Claim to include raw public key by value in SD-JWT.
+Note: How the public key is included in SD-JWT is out of scope of this document. It can be passed by value or by reference. Examples in this document use `sub_jwk` Claim to include raw public key by value in SD-JWT.
 
 With holder binding, the `SD-JWT-RELEASE` is signed by the holder using its private key. It therefore looks as follows:
 

--- a/main.md
+++ b/main.md
@@ -686,9 +686,10 @@ and revealing the claim names does not provide any additional information.
 
 ## Unlinkability 
 
-It is also important to note that this format enables selective disclosure of claims, but
-in itself it does not achieve unlinkability of the subject of an SD-SWT.
-
+Colluding issuer/verifier or verifier/verifier pairs could learn undisclosed holder claims by linking 
+issuance/presentation or two presentation sessions on the basis of unique values encoded in the SD-JWT
+(issuer signature, salts, digests, etc.) More advanced cryptographic schemes, outside the scope of
+this specification, can be used to prevent this type of linkability.
 
 # Acknowledgements {#Acknowledgements}
       

--- a/main.md
+++ b/main.md
@@ -662,14 +662,13 @@ guess.
 ## Minimum length of the salt
 
 The length of the randomly-generated portion of the salt SHOULD be at least 128 bits.
- 
 
 ## Choice of a hash function
 
-For the security of this scheme, the hash function is required to have the
-following property. Given a claim value, a salt, and the resulting hash, it is
-hard to find a second salt value so that `HASH(salt | claim_value)` equals the
-hash.
+For the security of this scheme, the hash function is required to be preimage and collision
+resistant, i.e., it is infeasible to calculate the salt and claim value that result in
+a particular digest, and it is infeasible to find a different salt and claim value pair that
+result in a matching digest, respectively.
 
 Furthermore the hash algorithms MD2, MD4, MD5, RIPEMD-160, and SHA-1 
 revealed fundamental weaknesses and they MUST NOT be used.

--- a/main.md
+++ b/main.md
@@ -686,9 +686,9 @@ and revealing the claim names does not provide any additional information.
 
 ## Unlinkability 
 
-Colluding issuer/verifier or verifier/verifier pairs could learn undisclosed holder claims by linking 
-issuance/presentation or two presentation sessions on the basis of unique values encoded in the SD-JWT
-(issuer signature, salts, digests, etc.) More advanced cryptographic schemes, outside the scope of
+Colluding issuer/verifier or verifier/verifier pairs could link issuance/presentation or two presentation sessions
+to the same user on the basis of unique values encoded in the SD-JWT
+(issuer signature, salts, digests, etc.). More advanced cryptographic schemes, outside the scope of
 this specification, can be used to prevent this type of linkability.
 
 # Acknowledgements {#Acknowledgements}

--- a/main.md
+++ b/main.md
@@ -253,7 +253,7 @@ subset of the same mapping).
 
 An SD-JWT is a JWT that MUST be signed using the issuer's private key. The
 payload of an SD-JWT MUST contain the `sd_digests` and `hash_alg` claims
-described in the following sections, and MAY contain a holder's public key or a reference
+described in the following, and MAY contain a holder's public key or a reference
 thereto, as well as further claims such as `iss`, `iat`, etc. as defined or
 required by the application using SD-JWTs.
 


### PR DESCRIPTION
Some editorial changes:
* Use (hash) digest instead of hash when describing the result of the hash operation
* I'm suggesting to make the salt size a SHOULD vs. a MUST: 1) it doesn't affect interop, 2) some use cases might need smaller salts (with the option of using stronger (time/memory) digest derivation functions (hash)) to reduce the size of the artefact (e.g., constrained QR codes).
* `_sd` --> `sd_digests`
* Trimmed down duplicated info
* More security consideration details for hash function
* Clarified unlinkability statement in privacy consideration
* Some typos