### PR TITLE
Add OIDC reference again (was needed after all)

### DIFF
--- a/main.md
+++ b/main.md
@@ -825,6 +825,28 @@ The work on this draft was started at OAuth Security Workshop 2022 in Trondheim,
 
 TBD
 
+<reference anchor="OIDC" target="https://openid.net/specs/openid-connect-core-1_0.html">
+  <front>
+    <title>OpenID Connect Core 1.0 incorporating errata set 1</title>
+    <author initials="N." surname="Sakimura" fullname="Nat Sakimura">
+      <organization>NRI</organization>
+    </author>
+    <author initials="J." surname="Bradley" fullname="John Bradley">
+      <organization>Ping Identity</organization>
+    </author>
+    <author initials="M." surname="Jones" fullname="Mike Jones">
+      <organization>Microsoft</organization>
+    </author>
+    <author initials="B." surname="de Medeiros" fullname="Breno de Medeiros">
+      <organization>Google</organization>
+    </author>
+    <author initials="C." surname="Mortimore" fullname="Chuck Mortimore">
+      <organization>Salesforce</organization>
+    </author>
+   <date day="8" month="Nov" year="2014"/>
+  </front>
+</reference>
+
 <reference anchor="VC_DATA" target="https://www.w3.org/TR/vc_data">
   <front>
     <title>Verifiable Credentials Data Model 1.0</title>


### PR DESCRIPTION
It seems that I missed the one place where @OIDC was used in the document when removing the reference. This PR adds it back into the document.